### PR TITLE
This change checks if a header node is in a few important categories

### DIFF
--- a/lib/graph_utils.py
+++ b/lib/graph_utils.py
@@ -20,7 +20,12 @@ def extract_symbols_from_file(filename: Path, flags: List[str], header = False) 
 
         else:
             name = node.spelling
-            symbols.add(name)
+            if node.kind in {
+                CursorKind.STRUCT_DECL, CursorKind.ENUM_DECL, CursorKind.TYPEDEF_DECL,
+                CursorKind.CLASS_DECL, CursorKind.FUNCTION_DECL,
+                CursorKind.MACRO_DEFINITION, CursorKind.FIELD_DECL,
+            }:
+                symbols.add(name)
             for child in node.get_children():
                 visit_node(child)
 


### PR DESCRIPTION
If it is in one of these categories it will be considered important otherwise it will not be. This prevents the following int func(int a, int b) from creating four important nodes:int func a and b and instead creating 2 int and func.