### PR TITLE
Linting + Readability Changes

### DIFF
--- a/hierarchical_agglomeration.py
+++ b/hierarchical_agglomeration.py
@@ -1,13 +1,16 @@
-import sys
-from collections import defaultdict
+import argparse
 import json
+from collections import defaultdict
+from pathlib import Path
+from typing import List, Tuple, Dict
+
+import numpy as np
 from scipy.cluster.hierarchy import linkage, dendrogram, fcluster
 import matplotlib.pyplot as plt
-import numpy as np
 
 from lib.graph_utils import extract_symbols_from_file
 
-def compute_proximity(header_filename, c_filenames):
+def compute_proximity(header_filename: Path, c_filenames: Path) -> Dict[Tuple[str, str], int]:
     with open(c_filenames) as json_data:
         header_symbols = extract_symbols_from_file(header_filename, [], header=True)
         proximity = defaultdict(int)
@@ -20,11 +23,11 @@ def compute_proximity(header_filename, c_filenames):
                         proximity[(sym1, sym2)] = len(pairings)
     return proximity
 
-def create_distance_matrix(proximity, symbols):
+def create_distance_matrix(proximity: Dict[Tuple[str, str], int], 
+                           symbols: List[str]) -> np.ndarray:
     n = len(symbols)
     LARGE_VALUE = 2
     matrix = np.full((n, n), LARGE_VALUE)
-    print(symbols, n)
     
     for i in range(n):
         for j in range(n):
@@ -38,7 +41,7 @@ def create_distance_matrix(proximity, symbols):
     return matrix
 
 
-def hierarchical_clustering(proximity):
+def hierarchical_clustering(proximity: Dict[Tuple[str, str], int]):
     symbols = list(extract_symbols_from_file(header_filename, [], header=True))
     distance_matrix = create_distance_matrix(proximity, symbols)
     linked = linkage(distance_matrix, method='average')
@@ -53,18 +56,28 @@ def hierarchical_clustering(proximity):
     return symbol_to_cluster
 
 if __name__ == "__main__":
-    if len(sys.argv) < 3:
-        print(f"Usage: {sys.argv[0]} <header_filename> <compile_commands.json>")
-        sys.exit(1)
+    parser = argparse.ArgumentParser(description='''This script finds the occurrences of 
+                                     tokens in a compile_commands.json.''')
+    parser.add_argument('-c', '--commands', type=Path, required=True,
+                        help='Path to compile_commands.json')
+    parser.add_argument('-f', '--header_filename', type=Path, required=True,
+                        help='Path to header')
+    parser.add_argument('-d', action='store_true',
+                        help='Debug mode on.')
+    args = parser.parse_args()
 
-    header_filename = sys.argv[1]
-    c_filenames = sys.argv[2]
+    header_filename = args.header_filename
+    c_filenames = args.commands
+    DEBUG = args.d
+    
     proximity = compute_proximity(header_filename, c_filenames)
 
-    sorted_data = sorted([(count, sym1, sym2) for (sym1, sym2), count in proximity.items()], reverse=True)
-    for count, sym1, sym2 in sorted_data:
-        print(f"Proximity SYM:{sym1} - SYM:{sym2}: {count}")
+    if DEBUG:
+        sorted_data = sorted([(count, sym1, sym2) for (sym1, sym2), count in proximity.items()], reverse=True)
+        for count, sym1, sym2 in sorted_data:
+            print(f"Proximity SYM:{sym1} - SYM:{sym2}: {count}")
 
     clusters = hierarchical_clustering(proximity)
-    for symbol, cluster_id in clusters.items():
-        print(f"Symbol {symbol} is in cluster {cluster_id}")
+    if DEBUG:
+        for symbol, cluster_id in clusters.items():
+            print(f"Symbol {symbol} is in cluster {cluster_id}")

--- a/hierarchical_agglomeration.py
+++ b/hierarchical_agglomeration.py
@@ -23,12 +23,12 @@ def compute_proximity(header_filename: Path, c_filenames: Path) -> Dict[Tuple[st
                         proximity[(sym1, sym2)] = len(pairings)
     return proximity
 
-def create_distance_matrix(proximity: Dict[Tuple[str, str], int], 
+def create_distance_matrix(proximity: Dict[Tuple[str, str], int],
                            symbols: List[str]) -> np.ndarray:
     n = len(symbols)
     LARGE_VALUE = 2
     matrix = np.full((n, n), LARGE_VALUE)
-    
+
     for i in range(n):
         for j in range(n):
             if i == j:
@@ -45,7 +45,7 @@ def hierarchical_clustering(proximity: Dict[Tuple[str, str], int]):
     symbols = list(extract_symbols_from_file(header_filename, [], header=True))
     distance_matrix = create_distance_matrix(proximity, symbols)
     linked = linkage(distance_matrix, method='average')
-    
+
     plt.figure(figsize=(10, 7))
     dendrogram(linked, orientation='top', labels=symbols, distance_sort='descending')
     plt.show()
@@ -56,7 +56,7 @@ def hierarchical_clustering(proximity: Dict[Tuple[str, str], int]):
     return symbol_to_cluster
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description='''This script finds the occurrences of 
+    parser = argparse.ArgumentParser(description='''This script finds the occurrences of
                                      tokens in a compile_commands.json.''')
     parser.add_argument('-c', '--commands', type=Path, required=True,
                         help='Path to compile_commands.json')
@@ -69,11 +69,12 @@ if __name__ == "__main__":
     header_filename = args.header_filename
     c_filenames = args.commands
     DEBUG = args.d
-    
+
     proximity = compute_proximity(header_filename, c_filenames)
 
     if DEBUG:
-        sorted_data = sorted([(count, sym1, sym2) for (sym1, sym2), count in proximity.items()], reverse=True)
+        sorted_data = sorted([(count, sym1, sym2) for (sym1, sym2), count in proximity.items()],
+                             reverse=True)
         for count, sym1, sym2 in sorted_data:
             print(f"Proximity SYM:{sym1} - SYM:{sym2}: {count}")
 

--- a/process_ast.py
+++ b/process_ast.py
@@ -26,8 +26,8 @@ def compute_usage(c_commands: Path):
                 print(future.result())
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description='''This script suggests an automatic partition of a
-                                    header file.''')
+    parser = argparse.ArgumentParser(description='''This script finds the occurrences of tokens in
+                                    a compile_commands.json.''')
     parser.add_argument('-c', '--commands', type=Path, required=True,
                         help='Path to compile_commands.json')
 


### PR DESCRIPTION
Switched to pathlib and argparse cleaned up a lot of common linter errors and made the code generally more readable.