### PR TITLE
Preventing Clogging of Symbol Table

### DIFF
--- a/lib/graph_utils.py
+++ b/lib/graph_utils.py
@@ -1,3 +1,4 @@
+'''functions used in performing hierarchical agglomeration'''
 from pathlib import Path
 from typing import List, Set
 from clang.cindex import Index, CursorKind
@@ -20,6 +21,7 @@ def extract_symbols_from_file(filename: Path, flags: List[str], header = False) 
 
         else:
             name = node.spelling
+
             if node.kind in {
                 CursorKind.STRUCT_DECL, CursorKind.ENUM_DECL, CursorKind.TYPEDEF_DECL,
                 CursorKind.CLASS_DECL, CursorKind.FUNCTION_DECL,
@@ -27,9 +29,11 @@ def extract_symbols_from_file(filename: Path, flags: List[str], header = False) 
             }:
                 if filename.name in str(node.location.file):
                     symbols.add(name)
+
             if node.kind in { CursorKind.FUNCTION_DECL }:
                 # Stops us from going into the function body because we don't care for headers
                 return
+
             for child in node.get_children():
                 visit_node(child, 1)
 

--- a/lib/graph_utils.py
+++ b/lib/graph_utils.py
@@ -5,8 +5,7 @@ from clang.cindex import Index, CursorKind
 
 usable_types = frozenset({
     CursorKind.STRUCT_DECL, CursorKind.ENUM_DECL, CursorKind.TYPEDEF_DECL,
-    CursorKind.CLASS_DECL, CursorKind.FUNCTION_DECL,
-    CursorKind.MACRO_DEFINITION, CursorKind.FIELD_DECL,
+    CursorKind.FUNCTION_DECL, CursorKind.MACRO_DEFINITION, CursorKind.FIELD_DECL,
 })
 
 def extract_symbols_from_file(filename: Path, flags: List[str], header = False) -> Set[str]:


### PR DESCRIPTION
Currently we pull in stuff from Asm-Generics such as __u16 and also use the insides of functions. Additionally for headers only the function name matters so we don't need to traverse the whole function.